### PR TITLE
Update Travis CI to use standard test script and go 1.9.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 go:
     - 1.9.x
 
-before_install:
+install:
   - make deps
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ os:
   - linux
   - osx
 
+sudo: false
+
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,13 @@ os:
 language: go
 
 go:
-    - 1.9
-
-install: true
+    - 1.9.x
 
 before_install:
   - make deps
 
 script:
-  - go vet
-  - $GOPATH/bin/goveralls -service="travis-ci"
+  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:
     directories:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,7 @@ gx:
 	go get github.com/whyrusleeping/gx
 	go get github.com/whyrusleeping/gx-go
 
-covertools:
-	go get github.com/mattn/goveralls
-	go get golang.org/x/tools/cmd/cover
-
-deps: gx covertools
+deps: gx
 	gx --verbose install --global
 	gx-go rewrite
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  range: "50...100"
+comment: off


### PR DESCRIPTION
This also switches from goveralls to codecov.